### PR TITLE
Build(deps): bump h11 from 0.14.0 to 0.16.0 in /backend in the pip gr…

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ dnspython==2.7.0
 email_validator==2.2.0
 fastapi==0.115.6
 fastapi-cli==0.0.7
-h11==0.14.0
+h11==0.16.0
 httpcore==1.0.7
 httptools==0.6.4
 httpx==0.28.1


### PR DESCRIPTION
…oup across 1 directory (#19)

* v1.2.3 (#17)

security: update jinja2 v 3.1.6 (#16)

* Build(deps): bump h11 in /backend in the pip group across 1 directory

Bumps the pip group with 1 update in the /backend directory: [h11](https://github.com/python-hyper/h11).


Updates `h11` from 0.14.0 to 0.16.0
- [Commits](https://github.com/python-hyper/h11/compare/v0.14.0...v0.16.0)

---
updated-dependencies:
- dependency-name: h11 dependency-version: 0.16.0 dependency-type: direct:production dependency-group: pip ...



---------